### PR TITLE
Rubicon YAML configuration.

### DIFF
--- a/pbs.yaml
+++ b/pbs.yaml
@@ -2,3 +2,9 @@ cache:
   scheme: https
   host: prebid-cache.pub.network
   query: uuid=%PBS_CACHE_UUID%
+adapters:
+  rubicon:
+    usersync_url: http://pixel.rubiconproject.com/sync.php?p=prebid
+    xapi:
+      username: freestarmedia
+      password: YUG3546FGR

--- a/pbs.yaml.production
+++ b/pbs.yaml.production
@@ -2,3 +2,9 @@ cache:
   scheme: https
   host: prebid-cache.pub.network
   query: uuid=%PBS_CACHE_UUID%
+adapters:
+  rubicon:
+    usersync_url: http://pixel.rubiconproject.com/sync.php?p=prebid
+    xapi:
+      username: freestarmedia
+      password: YUG3546FGR


### PR DESCRIPTION
This config contains XAPI username and password info.  Is this ok?  Or is there a different way to store credentials?